### PR TITLE
Refactor: Remove unnecessary code

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1,5 +1,4 @@
 import os
-import sublime
 from lsp_utils import NpmClientHandler
 
 
@@ -15,7 +14,3 @@ class LspAngularPlugin(NpmClientHandler):
     package_name = __package__
     server_directory = "server"
     server_binary_path = os.path.join(server_directory, "node_modules", "@angular", "language-server", "index.js")
-
-    @classmethod
-    def install_in_cache(cls) -> bool:
-        return False


### PR DESCRIPTION
The "install_in_cache" part is no longer required because it's the default.