### PR TITLE
Fix: Use ${node_bin} for the node binary

### DIFF
--- a/LSP-angular.sublime-settings
+++ b/LSP-angular.sublime-settings
@@ -1,6 +1,6 @@
 {
 	"command": [
-		"node", "${server_path}",
+		"${node_bin}", "${server_path}",
 		"--logFile", "${server_directory_path}/ngls.log",
 		"--ngProbeLocations", "${server_directory_path}/node_modules",
 		"--tsProbeLocations", "${server_directory_path}/node_modules",


### PR DESCRIPTION
With the latest version of lsp_utils a change was introduced [1] that allows using a locally
managed node runtime instead of the system one. For that to work, the "node" command
needs to use a variable.

[1] https://github.com/sublimelsp/lsp_utils/commit/403345a0c5c15e84802c712044c630a9fb236b9d