### PR TITLE
refactor: replace deprecated initializationOptions with initialization_options

### DIFF
--- a/LSP-angular.sublime-settings
+++ b/LSP-angular.sublime-settings
@@ -8,8 +8,6 @@
 	],
 	"priority_selector": "source.ts meta.annotation string.quoted, source.js meta.annotation string.quoted",
 	"selector": "text.html.ngx | source.ts | source.js",
-	"disabled_capabilities": {},
-	"initialization_options": {},
 	"settings": {
 		"angular.log": "off",
 		"angular.enable-strict-mode-prompt": true,

--- a/LSP-angular.sublime-settings
+++ b/LSP-angular.sublime-settings
@@ -9,7 +9,7 @@
 	"priority_selector": "source.ts meta.annotation string.quoted, source.js meta.annotation string.quoted",
 	"selector": "text.html.ngx | source.ts | source.js",
 	"disabled_capabilities": {},
-	"initializationOptions": {},
+	"initialization_options": {},
 	"settings": {
 		"angular.log": "off",
 		"angular.enable-strict-mode-prompt": true,

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -18,7 +18,7 @@
                     "definitions": {
                         "PluginConfig": {
                             "properties": {
-                                "initializationOptions": {
+                                "initialization_options": {
                                     "additionalProperties": false,
                                     "properties": {}
                                 },


### PR DESCRIPTION
In https://github.com/sublimelsp/LSP/releases/tag/4070-2.9.0 `config.init_options`
and `initializationOptions` in settings were deprecated.

(This is a semi-automatically created PR that might not
have been tested manually.)
